### PR TITLE
Update README for default view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 AIRTABLE_API_KEY=your_airtable_key
 AIRTABLE_BASE_ID=your_base_id
 AIRTABLE_TABLE_NAME=Recipes
+AIRTABLE_VIEW_NAME=Grid view

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This is a simple web app for managing recipes tailored for women with gestationa
    - `AIRTABLE_API_KEY` – your Airtable API key (**do not commit secrets to git**).
    - `AIRTABLE_BASE_ID` – the base ID (not the name) containing the recipes.
    - `AIRTABLE_TABLE_NAME` – (optional) table name, defaults to `Recipes`.
+   - `AIRTABLE_VIEW_NAME` – (optional) Airtable view to query, defaults to `Grid view`.
+
+By default the server queries the **Grid view**. Set `AIRTABLE_VIEW_NAME` if you need to use a different view.
+
 3. Start the server:
    ```bash
    node server.js

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const Airtable = require('airtable');
 const cors = require('cors');
 const path = require('path');
+const viewName = process.env.AIRTABLE_VIEW_NAME || 'Grid view';
 
 const app = express();
 app.use(cors());
@@ -13,7 +14,7 @@ const tableName = process.env.AIRTABLE_TABLE_NAME || 'Recipes';
 app.get('/api/recipes', async (req, res) => {
   const filter = req.query.tag;
   try {
-    const records = await base(tableName).select().all();
+    const records = await base(tableName).select({ view: viewName }).all();
     const recipes = records.map(rec => ({ id: rec.id, ...rec.fields }));
     let filtered = recipes;
     if (filter) {


### PR DESCRIPTION
## Summary
- document the Grid view defaults in README
- support `AIRTABLE_VIEW_NAME` env var to select a different view

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68431058249883289560ea7dca92f6ec