### PR TITLE
Add dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ This is a simple web app for managing recipes tailored for women with gestationa
    ```bash
    npm install
    ```
-2. Set the following environment variables:
+2. Copy `.env.example` to `.env` and edit the values:
+   ```bash
+   cp .env.example .env
+   ```
+   Then set the following environment variables in `.env`:
    - `AIRTABLE_API_KEY` – your Airtable API key (**do not commit secrets to git**).
    - `AIRTABLE_BASE_ID` – the base ID (not the name) containing the recipes.
    - `AIRTABLE_TABLE_NAME` – (optional) table name, defaults to `Recipes`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "airtable": "^0.12.2",
         "cors": "^2.8.5",
+        "dotenv": "^16.5.0",
         "express": "^4.21.2"
       }
     },
@@ -210,6 +211,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "airtable": "^0.12.2",
     "cors": "^2.8.5",
+    "dotenv": "^16.5.0",
     "express": "^4.21.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const Airtable = require('airtable');
 const cors = require('cors');


### PR DESCRIPTION
## Summary
- install dotenv and add it to dependencies
- load environment variables in `server.js`
- document how to create a `.env` file from `.env.example`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684314b6d88c8328b0141a30ee04fb76